### PR TITLE
Se agrega explicaciones para los modos continuo y secuencial

### DIFF
--- a/app/src/main/java/appinventor/ai_andres_piegari/TeEscuchoDCH6j/Clasico.java
+++ b/app/src/main/java/appinventor/ai_andres_piegari/TeEscuchoDCH6j/Clasico.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.PreferenceManager;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -52,6 +53,7 @@ public class Clasico extends AppCompatActivity {
     int seekValue;
     public String TextoCompleto = " ";
     static Boolean clasicoActiva = false;
+
 
     // Creación de la barra superior, para que aparezca la ruedita de configuración
     @Override
@@ -246,6 +248,18 @@ public class Clasico extends AppCompatActivity {
     public void onStart() {
         super.onStart();
         clasicoActiva = false;
+
+        // Se lee contador de inicios https://stackoverflow.com/a/25032996
+        // Se muestra un Toast explicando el modo secuencial
+        SharedPreferences prefs = getSharedPreferences("GLOBAL_PREFERENCES", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = prefs.edit();
+        int init_counter = prefs.getInt("init_counter", 0);
+        boolean tooltip_shown = prefs.getBoolean("tooltip_shown_sequence_mode", false);
+        if(init_counter < 3 && !tooltip_shown){
+            Toast.makeText(this, R.string.tooltip_sequence_mode, Toast.LENGTH_LONG).show();
+            editor.putBoolean("tooltip_shown_sequence_mode", true);
+            editor.apply();
+        }
     }
 
 

--- a/app/src/main/java/appinventor/ai_andres_piegari/TeEscuchoDCH6j/Inicio.java
+++ b/app/src/main/java/appinventor/ai_andres_piegari/TeEscuchoDCH6j/Inicio.java
@@ -2,10 +2,10 @@ package appinventor.ai_andres_piegari.TeEscuchoDCH6j;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
-
-import appinventor.ai_andres_piegari.TeEscuchoDCH6j.R;
 
 import java.util.Timer;
 import java.util.TimerTask;
@@ -30,6 +30,16 @@ public class Inicio extends AppCompatActivity {
             }
 
         },5000);
+
+        // Agregar contador de inicios https://stackoverflow.com/a/25032996
+        SharedPreferences prefs = getSharedPreferences("GLOBAL_PREFERENCES", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = prefs.edit();
+        int init_counter = prefs.getInt("init_counter", 0);
+        init_counter++;
+        editor.putInt("init_counter", init_counter);
+        editor.putBoolean("tooltip_shown_sequence_mode", false);
+        editor.putBoolean("tooltip_shown_continuous_mode", false);
+        editor.apply();
     }
 
 }

--- a/app/src/main/java/appinventor/ai_andres_piegari/TeEscuchoDCH6j/KaldiActivity.java
+++ b/app/src/main/java/appinventor/ai_andres_piegari/TeEscuchoDCH6j/KaldiActivity.java
@@ -4,6 +4,7 @@ package appinventor.ai_andres_piegari.TeEscuchoDCH6j;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -90,6 +91,7 @@ public class KaldiActivity extends AppCompatActivity implements
     public static final  boolean MODO_OSCURO = false;
     static boolean continuoActiva = false;
     static Activity actividad;
+    private boolean tooltip_shown = false;
 
     // Creación de la barra superior, para que aparezca la ruedita de configuración
     @Override
@@ -226,29 +228,22 @@ public class KaldiActivity extends AppCompatActivity implements
         //En el caso del modo continuo, tuve que hacer unas cosas para que cuando se gire el teléfono
         //no vueva  a empezar. Por eso está la variblae resetApp. Ahora lo que hago es cambiar la gráfica
         //Si se resetea la app, para que siga grabando.
-
-
         if(resetApp){
             recMic.setImageResource(R.drawable.ic_pause_24px);
             recMic.setEnabled(true);
         }
         else{
             recMic.setImageResource(R.drawable.oreja_negra);
-
         }
 
-
         if(statusUi==4){
-        setUiState(STATE_MIC);
+            setUiState(STATE_MIC);
         }
         else{
             setUiState(STATE_START);
         }
 
-
-
         // Check if user has given permission to record audio
-
         int permissionCheck = ContextCompat.checkSelfPermission(getApplicationContext(), Manifest.permission.RECORD_AUDIO);
         if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO}, PERMISSIONS_REQUEST_RECORD_AUDIO);
@@ -287,6 +282,18 @@ public class KaldiActivity extends AppCompatActivity implements
     public void onStart() {
         super.onStart();
         continuoActiva = false;
+
+        // Se lee contador de inicios https://stackoverflow.com/a/25032996
+        // Se muestra un Toast explicando el modo continuo
+        SharedPreferences prefs = getSharedPreferences("GLOBAL_PREFERENCES", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = prefs.edit();
+        int init_counter = prefs.getInt("init_counter", 0);
+        boolean tooltip_shown = prefs.getBoolean("tooltip_shown_continuous_mode", false);
+        if(init_counter < 3 && !tooltip_shown){
+            Toast.makeText(this, R.string.tooltip_continuos_mode, Toast.LENGTH_LONG).show();
+            editor.putBoolean("tooltip_shown_continuous_mode", true);
+            editor.apply();
+        }
     }
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
     <string name="button_change_continuos_mode">Cambiar a modo continuo</string>
     <string name="button_change_sequential_mode">Cambiar a modo secuencial</string>
     <string name="button_share">Compartir la transcripción</string>
+    <string name="tooltip_sequence_mode">En el modo secuencial la escucha durará unos segundos y las transcripciones no se acumulan. Cambie a modo continuo presionando el botón de abajo a la izquierda</string>
+    <string name="tooltip_continuos_mode">En el modo continuo la escucha durará hasta que se detenga manualmente y las transcripciones se acumularán en un único texto. Cambie a modo secuencial presionando el botón de abajo a la izquierda</string>
 
     <!-- Preference Titles -->
     <string name="messages_header">Messages</string>


### PR DESCRIPTION
De acuerdo al #10 se agregan mensajes explicativos en el modo continuo y en el secuencial durante los primeros dos inicios de la aplicación, una vez por cada actividad.

Interfaz del modo continuo:

![Screenshot_20211114-225316](https://user-images.githubusercontent.com/33455687/141712452-e3aeaed2-6093-4e29-a827-dc7651f39dc5.png)

Interfaz del modo secuencial:

![Screenshot_20211114-225257](https://user-images.githubusercontent.com/33455687/141712485-abf62c9b-5095-4294-999b-56ecc9c5edf5.png)
